### PR TITLE
Add a --quiet option to import the first certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.class
 *.cert
 jssecacerts
+.idea
+out/*
+*.iml

--- a/InstallCert.java
+++ b/InstallCert.java
@@ -182,7 +182,7 @@ public class InstallCert {
 
         int k;
         if (isQuiet) {
-            k = 1;
+            k = 0;
         }
         else {
             System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");

--- a/InstallCert.java
+++ b/InstallCert.java
@@ -182,6 +182,7 @@ public class InstallCert {
 
         int k;
         if (isQuiet) {
+            System.out.println("Adding first certificate to trusted keystore");
             k = 0;
         }
         else {

--- a/InstallCert.java
+++ b/InstallCert.java
@@ -183,7 +183,6 @@ public class InstallCert {
         int k;
         if (isQuiet) {
             System.out.println("Adding first certificate to trusted keystore");
-            k = 0;
         }
         else {
             System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");

--- a/InstallCert.java
+++ b/InstallCert.java
@@ -183,6 +183,7 @@ public class InstallCert {
         int k;
         if (isQuiet) {
             System.out.println("Adding first certificate to trusted keystore");
+            k = 0;
         }
         else {
             System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");

--- a/InstallCert.java
+++ b/InstallCert.java
@@ -69,6 +69,7 @@ public class InstallCert {
         int numArg = 0;
         int nbArgs = args.length;
         boolean invalidArgs = false;
+        boolean isQuiet = false;
         while (numArg < nbArgs) {
             String arg = args[numArg++];
             if (arg.startsWith("--proxy=")) {
@@ -77,6 +78,9 @@ public class InstallCert {
                 String[] c = proxy.split(":");
                 proxyHost = c[0];
                 proxyPort = Integer.parseInt(c[1]);  // proxy port is mandatory (we don't default to 8080)
+            }
+            else if (arg.startsWith("--quiet")) {
+                isQuiet = true;
             }
             else if (host == null) {  // 1st argument is the "host:port"
                 String[] c = arg.split(":");
@@ -96,7 +100,7 @@ public class InstallCert {
         }
 
         if (invalidArgs) {
-            System.out.println("Usage: java InstallCert [--proxy=proxyHost:proxyPort] host[:port] [passphrase]");
+            System.out.println("Usage: java InstallCert [--proxy=proxyHost:proxyPort] host[:port] [passphrase] [--quiet]");
             return;
         }
 
@@ -176,14 +180,19 @@ public class InstallCert {
             System.out.println();
         }
 
-        System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");
-        String line = reader.readLine().trim();
         int k;
-        try {
-            k = (line.length() == 0) ? 0 : Integer.parseInt(line) - 1;
-        } catch (NumberFormatException e) {
-            System.out.println("KeyStore not changed");
-            return;
+        if (isQuiet) {
+            k = 1;
+        }
+        else {
+            System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");
+            String line = reader.readLine().trim();
+            try {
+                k = (line.length() == 0) ? 0 : Integer.parseInt(line) - 1;
+            } catch (NumberFormatException e) {
+                System.out.println("KeyStore not changed");
+                return;
+            }
         }
 
         X509Certificate cert = chain[k];


### PR DESCRIPTION
I was trying to use this from a build script and it kept prompting me to select a certificate.
This modification solved my problem.

It automatically selects the first certificate.